### PR TITLE
Rename the helm chart release_name variable for Kapitan to name

### DIFF
--- a/class/ingress-nginx.yml
+++ b/class/ingress-nginx.yml
@@ -22,5 +22,5 @@ parameters:
           - ingress-nginx/helmcharts/ingress-nginx/${ingress_nginx:charts:ingress-nginx}/
         helm_values: ${ingress_nginx:helm_values}
         helm_params:
-          release_name: ${ingress_nginx:release_name}
+          name: ${ingress_nginx:release_name}
           namespace: ${ingress_nginx:namespace}


### PR DESCRIPTION
Kapitan has changed the helm chart naming and release_name is
now deprecated.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

