### PR TITLE
Add support for Pod Security Admission labels

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -6,7 +6,7 @@ parameters:
       ingress-nginx: '4.2.3'
     chroot: false
     pod_security_admission:
-      enabled: true
+      enabled: false
       enforce: privileged
       audit: privileged
       warn: privileged

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -5,6 +5,11 @@ parameters:
     charts:
       ingress-nginx: '4.2.3'
     chroot: false
+    pod_security_admission:
+      enabled: true
+      enforce: privileged
+      audit: privileged
+      warn: privileged
     helm_values:
       controller:
         image:

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -52,20 +52,20 @@ pod_security_admission:
   audit: privileged <3>
   warn: privileged <4>
 ----
-<1> Wether to set any Pod Security Admission labels
+<1> Whether to set any Pod Security Admission labels
 <2> Which Pod Security Standard to enforce in the created namespace
 <3> Which Pod Security Standard to audit in the created namespace
 <4> Which Pod Security Standard to warn on in the created namespace
 
 The Pod Security Admission configuration.
-Pod Security Admission can be enabled or disabled and which standard to enforce, warn, or audit on can be configured.
+Pod Security Admission can be enabled or disabled and the standard  to use for enforce, warn, and audit can be configured.
 
-You can remove any of the label by setting the repecitive field to an empty string or `null`.
+You can remove any of the labels by setting the respective field to an empty string or `null`.
 
 Please consult the https://kubernetes.io/docs/concepts/security/pod-security-admission/[upstream documentation].
 
 NOTE: We default to enforce the `privileged` standard.
-As of writing this the helm chart sets `allowPrivilegeEscalation: true`, which is only allowd for privileged workloads.
+As of writing this the helm chart sets `allowPrivilegeEscalation: true`, which is only allowed for privileged workloads.
 However, this is most likely not needed and if the upstream chart changes this default should be reevaluated.
 
 == `charts.ingress-nginx`

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -47,7 +47,7 @@ default::
 [source,yaml]
 ----
 pod_security_admission:
-  enabled: true <1>
+  enabled: false <1>
   enforce: privileged <2>
   audit: privileged <3>
   warn: privileged <4>
@@ -58,8 +58,8 @@ pod_security_admission:
 <4> Which Pod Security Standard to warn on in the created namespace
 
 The Pod Security Admission configuration.
-Pod Security Admission can be enabled or disabled and the standard  to use for enforce, warn, and audit can be configured.
 
+Pod Security Admission can be enabled or disabled and the standard to use for enforce, warn, and audit can be configured.
 You can remove any of the labels by setting the respective field to an empty string or `null`.
 
 Please consult the https://kubernetes.io/docs/concepts/security/pod-security-admission/[upstream documentation].

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -37,6 +37,37 @@ default:: `false`
 Whether to enable the chrooted web proxy server.
 Please see the xref:how-tos/enable-chroot.adoc[chroot how-to].
 
+
+== `pod_security_admission`
+
+[horizontal]
+type:: dict
+default::
+
+[source,yaml]
+----
+pod_security_admission:
+  enabled: true <1>
+  enforce: privileged <2>
+  audit: privileged <3>
+  warn: privileged <4>
+----
+<1> Wether to set any Pod Security Admission labels
+<2> Which Pod Security Standard to enforce in the created namespace
+<3> Which Pod Security Standard to audit in the created namespace
+<4> Which Pod Security Standard to warn on in the created namespace
+
+The Pod Security Admission configuration.
+Pod Security Admission can be enabled or disabled and which standard to enforce, warn, or audit on can be configured.
+
+You can remove any of the label by setting the repecitive field to an empty string or `null`.
+
+Please consult the https://kubernetes.io/docs/concepts/security/pod-security-admission/[upstream documentation].
+
+NOTE: We default to enforce the `privileged` standard.
+As of writing this the helm chart sets `allowPrivilegeEscalation: true`, which is only allowd for privileged workloads.
+However, this is most likely not needed and if the upstream chart changes this default should be reevaluated.
+
 == `charts.ingress-nginx`
 
 [horizontal]

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -3,6 +3,7 @@ parameters:
     kubernetes_version: "1.21"
     chroot: true
     pod_security_admission:
+      enabled: true
       enforce: privileged
       audit: ''
       warn: null

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -2,3 +2,7 @@ parameters:
   ingress_nginx:
     kubernetes_version: "1.21"
     chroot: true
+    pod_security_admission:
+      enforce: privileged
+      audit: ''
+      warn: null

--- a/tests/golden/defaults/ingress-nginx/ingress-nginx/00_namespace.yaml
+++ b/tests/golden/defaults/ingress-nginx/ingress-nginx/00_namespace.yaml
@@ -4,4 +4,5 @@ metadata:
   annotations: {}
   labels:
     name: syn-ingress-nginx
+    pod-security.kubernetes.io/enforce: privileged
   name: syn-ingress-nginx


### PR DESCRIPTION
This PR sets Pod Security Admission labels to `privileged`. This ensures that the ingress controller can run on clusters with more restrictive default Pod Security Admission rules.

For any cluster that has not yet enabled Pod Security Admission this should be a Noop.


Closes #52 

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
