### PR TITLE
Change to the default electionID to the Helm chart default

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -14,8 +14,6 @@ parameters:
       controller:
         image:
           chroot: ${ingress_nginx:chroot}
-        # Workaround prevent changing election-id=ingress-controller-leader to election-id=ingress-nginx-leader
-        electionID: ingress-controller-leader
         publishService:
           enabled: true
           pathOverride: "syn-ingress-nginx/ingress-nginx-controller"

--- a/docs/modules/ROOT/pages/how-tos/upgrade-7.x-to-8.x.adoc
+++ b/docs/modules/ROOT/pages/how-tos/upgrade-7.x-to-8.x.adoc
@@ -1,0 +1,27 @@
+= Upgrade from 7.x to 8.x
+
+This guide describes the steps to perform an upgrade of the component from version 7.x to 8.x.
+
+== Introduction
+
+The helm chart v4.4.0 did introduce a change[https://github.com/kubernetes/ingress-nginx/commit/249780737c862a7cf690058511ee7126ddd0d788] of the `election-id` from `ingress-controller-leader` to `ingress-nginx-leader`.
+Changing the electionID might cause a ingress service interrupt until all NGINX Ingress components have been upgraded.
+During the upgrade the leader might not be choosen correctly.
+
+== Step-by-step guide
+
+. Before upgrading to the latest version, you can optionally add following config to preserve the original electionID naming:
+
++
+[source,yaml]
+----
+parameters:
+  ingress_nginx:
+    helm_values:
+      controller:
+        electionID: ingress-controller-leader
+----
++
+
+[WARNING]
+Not preserving the electionID might cause a downtime on the ingress path!

--- a/docs/modules/ROOT/partials/nav.adoc
+++ b/docs/modules/ROOT/partials/nav.adoc
@@ -7,6 +7,7 @@
 * xref:how-tos/upgrade-4.x-to-5.x.adoc[Upgrade 4.x to 5.x]
 * xref:how-tos/upgrade-5.x-to-6.x.adoc[Upgrade 5.x to 6.x]
 * xref:how-tos/upgrade-6.x-to-7.x.adoc[Upgrade 6.x to 7.x]
+* xref:how-tos/upgrade-7.x-to-8.x.adoc[Upgrade 7.x to 8.x]
 * xref:cluster-default-ingress-class.adoc[Cluster Default IngressClass]
 * xref:how-tos/aws.adoc[AWS - Amazon Web Services Load Balancers]
 * xref:how-tos/logformat.adoc[NGINX upstream log format as JSON]

--- a/tests/golden/defaults/ingress-nginx/ingress-nginx/10_ingress_nginx_helmchart/ingress-nginx/templates/controller-deployment.yaml
+++ b/tests/golden/defaults/ingress-nginx/ingress-nginx/10_ingress_nginx_helmchart/ingress-nginx/templates/controller-deployment.yaml
@@ -31,7 +31,7 @@ spec:
         - args:
             - /nginx-ingress-controller
             - --publish-service=syn-ingress-nginx/ingress-nginx-controller
-            - --election-id=ingress-controller-leader
+            - --election-id=ingress-nginx-leader
             - --controller-class=k8s.io/ingress-nginx
             - --ingress-class=nginx
             - --configmap=$(POD_NAMESPACE)/ingress-nginx-controller

--- a/tests/golden/defaults/ingress-nginx/ingress-nginx/10_ingress_nginx_helmchart/ingress-nginx/templates/controller-role.yaml
+++ b/tests/golden/defaults/ingress-nginx/ingress-nginx/10_ingress_nginx_helmchart/ingress-nginx/templates/controller-role.yaml
@@ -62,7 +62,7 @@ rules:
   - apiGroups:
       - coordination.k8s.io
     resourceNames:
-      - ingress-controller-leader
+      - ingress-nginx-leader
     resources:
       - leases
     verbs:


### PR DESCRIPTION
The helm chart v4.4.0 did introduce a change of the `election-id` from `ingress-controller-leader` to `ingress-nginx-leader`. Changing the electionID might cause a ingress service interrupt until all NGINX Ingress components have been upgraded. During the upgrade the leader might not be chosen correctly.

Ref: https://github.com/kubernetes/ingress-nginx/commit/249780737c862a7cf690058511ee7126ddd0d788

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.


