### PR TITLE
Upgrade helm chart to v4.7.0 and NGNIX Ingress Controller version v1.8

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -3,7 +3,7 @@ parameters:
     namespace: syn-ingress-nginx
     release_name: ingress-nginx
     charts:
-      ingress-nginx: '4.5.2'
+      ingress-nginx: '4.7.0'
     chroot: false
     pod_security_admission:
       enabled: false

--- a/docs/modules/ROOT/pages/how-tos/upgrade-7.x-to-8.x.adoc
+++ b/docs/modules/ROOT/pages/how-tos/upgrade-7.x-to-8.x.adoc
@@ -8,6 +8,8 @@ The helm chart v4.4.0 did introduce a change[https://github.com/kubernetes/ingre
 Changing the electionID might cause a ingress service interrupt until all NGINX Ingress components have been upgraded.
 During the upgrade the leader might not be choosen correctly.
 
+With this release the support for Kubernetes 1.23 has been removed.
+
 == Step-by-step guide
 
 . Before upgrading to the latest version, you can optionally add following config to preserve the original electionID naming:

--- a/tests/golden/defaults/ingress-nginx/ingress-nginx/10_ingress_nginx_helmchart/ingress-nginx/templates/admission-webhooks/job-patch/clusterrole.yaml
+++ b/tests/golden/defaults/ingress-nginx/ingress-nginx/10_ingress_nginx_helmchart/ingress-nginx/templates/admission-webhooks/job-patch/clusterrole.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.6.4
-    helm.sh/chart: ingress-nginx-4.5.2
+    app.kubernetes.io/version: 1.8.0
+    helm.sh/chart: ingress-nginx-4.7.0
   name: ingress-nginx-admission
 rules:
   - apiGroups:

--- a/tests/golden/defaults/ingress-nginx/ingress-nginx/10_ingress_nginx_helmchart/ingress-nginx/templates/admission-webhooks/job-patch/clusterrolebinding.yaml
+++ b/tests/golden/defaults/ingress-nginx/ingress-nginx/10_ingress_nginx_helmchart/ingress-nginx/templates/admission-webhooks/job-patch/clusterrolebinding.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.6.4
-    helm.sh/chart: ingress-nginx-4.5.2
+    app.kubernetes.io/version: 1.8.0
+    helm.sh/chart: ingress-nginx-4.7.0
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/defaults/ingress-nginx/ingress-nginx/10_ingress_nginx_helmchart/ingress-nginx/templates/admission-webhooks/job-patch/job-createSecret.yaml
+++ b/tests/golden/defaults/ingress-nginx/ingress-nginx/10_ingress_nginx_helmchart/ingress-nginx/templates/admission-webhooks/job-patch/job-createSecret.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.6.4
-    helm.sh/chart: ingress-nginx-4.5.2
+    app.kubernetes.io/version: 1.8.0
+    helm.sh/chart: ingress-nginx-4.7.0
   name: ingress-nginx-admission-create
   namespace: syn-ingress-nginx
 spec:
@@ -23,8 +23,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
-        app.kubernetes.io/version: 1.6.4
-        helm.sh/chart: ingress-nginx-4.5.2
+        app.kubernetes.io/version: 1.8.0
+        helm.sh/chart: ingress-nginx-4.7.0
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -38,7 +38,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20220916-gd32f8c343@sha256:39c5b2e3310dc4264d638ad28d9d1d96c4cbb2b2dcfb52368fe4e3c63f61e10f
+          image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20230407@sha256:543c40fd093964bc9ab509d3e791f9989963021f1e9e4c9c7b6700b02bfb227b
           imagePullPolicy: IfNotPresent
           name: create
           securityContext:

--- a/tests/golden/defaults/ingress-nginx/ingress-nginx/10_ingress_nginx_helmchart/ingress-nginx/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
+++ b/tests/golden/defaults/ingress-nginx/ingress-nginx/10_ingress_nginx_helmchart/ingress-nginx/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.6.4
-    helm.sh/chart: ingress-nginx-4.5.2
+    app.kubernetes.io/version: 1.8.0
+    helm.sh/chart: ingress-nginx-4.7.0
   name: ingress-nginx-admission-patch
   namespace: syn-ingress-nginx
 spec:
@@ -23,8 +23,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
-        app.kubernetes.io/version: 1.6.4
-        helm.sh/chart: ingress-nginx-4.5.2
+        app.kubernetes.io/version: 1.8.0
+        helm.sh/chart: ingress-nginx-4.7.0
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -40,7 +40,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20220916-gd32f8c343@sha256:39c5b2e3310dc4264d638ad28d9d1d96c4cbb2b2dcfb52368fe4e3c63f61e10f
+          image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20230407@sha256:543c40fd093964bc9ab509d3e791f9989963021f1e9e4c9c7b6700b02bfb227b
           imagePullPolicy: IfNotPresent
           name: patch
           securityContext:

--- a/tests/golden/defaults/ingress-nginx/ingress-nginx/10_ingress_nginx_helmchart/ingress-nginx/templates/admission-webhooks/job-patch/role.yaml
+++ b/tests/golden/defaults/ingress-nginx/ingress-nginx/10_ingress_nginx_helmchart/ingress-nginx/templates/admission-webhooks/job-patch/role.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.6.4
-    helm.sh/chart: ingress-nginx-4.5.2
+    app.kubernetes.io/version: 1.8.0
+    helm.sh/chart: ingress-nginx-4.7.0
   name: ingress-nginx-admission
   namespace: syn-ingress-nginx
 rules:

--- a/tests/golden/defaults/ingress-nginx/ingress-nginx/10_ingress_nginx_helmchart/ingress-nginx/templates/admission-webhooks/job-patch/rolebinding.yaml
+++ b/tests/golden/defaults/ingress-nginx/ingress-nginx/10_ingress_nginx_helmchart/ingress-nginx/templates/admission-webhooks/job-patch/rolebinding.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.6.4
-    helm.sh/chart: ingress-nginx-4.5.2
+    app.kubernetes.io/version: 1.8.0
+    helm.sh/chart: ingress-nginx-4.7.0
   name: ingress-nginx-admission
   namespace: syn-ingress-nginx
 roleRef:

--- a/tests/golden/defaults/ingress-nginx/ingress-nginx/10_ingress_nginx_helmchart/ingress-nginx/templates/admission-webhooks/job-patch/serviceaccount.yaml
+++ b/tests/golden/defaults/ingress-nginx/ingress-nginx/10_ingress_nginx_helmchart/ingress-nginx/templates/admission-webhooks/job-patch/serviceaccount.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.6.4
-    helm.sh/chart: ingress-nginx-4.5.2
+    app.kubernetes.io/version: 1.8.0
+    helm.sh/chart: ingress-nginx-4.7.0
   name: ingress-nginx-admission
   namespace: syn-ingress-nginx

--- a/tests/golden/defaults/ingress-nginx/ingress-nginx/10_ingress_nginx_helmchart/ingress-nginx/templates/admission-webhooks/validating-webhook.yaml
+++ b/tests/golden/defaults/ingress-nginx/ingress-nginx/10_ingress_nginx_helmchart/ingress-nginx/templates/admission-webhooks/validating-webhook.yaml
@@ -8,8 +8,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.6.4
-    helm.sh/chart: ingress-nginx-4.5.2
+    app.kubernetes.io/version: 1.8.0
+    helm.sh/chart: ingress-nginx-4.7.0
   name: ingress-nginx-admission
 webhooks:
   - admissionReviewVersions:

--- a/tests/golden/defaults/ingress-nginx/ingress-nginx/10_ingress_nginx_helmchart/ingress-nginx/templates/clusterrole.yaml
+++ b/tests/golden/defaults/ingress-nginx/ingress-nginx/10_ingress_nginx_helmchart/ingress-nginx/templates/clusterrole.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.6.4
-    helm.sh/chart: ingress-nginx-4.5.2
+    app.kubernetes.io/version: 1.8.0
+    helm.sh/chart: ingress-nginx-4.7.0
   name: ingress-nginx
 rules:
   - apiGroups:

--- a/tests/golden/defaults/ingress-nginx/ingress-nginx/10_ingress_nginx_helmchart/ingress-nginx/templates/clusterrolebinding.yaml
+++ b/tests/golden/defaults/ingress-nginx/ingress-nginx/10_ingress_nginx_helmchart/ingress-nginx/templates/clusterrolebinding.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.6.4
-    helm.sh/chart: ingress-nginx-4.5.2
+    app.kubernetes.io/version: 1.8.0
+    helm.sh/chart: ingress-nginx-4.7.0
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/defaults/ingress-nginx/ingress-nginx/10_ingress_nginx_helmchart/ingress-nginx/templates/controller-configmap.yaml
+++ b/tests/golden/defaults/ingress-nginx/ingress-nginx/10_ingress_nginx_helmchart/ingress-nginx/templates/controller-configmap.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.6.4
-    helm.sh/chart: ingress-nginx-4.5.2
+    app.kubernetes.io/version: 1.8.0
+    helm.sh/chart: ingress-nginx-4.7.0
   name: ingress-nginx-controller
   namespace: syn-ingress-nginx

--- a/tests/golden/defaults/ingress-nginx/ingress-nginx/10_ingress_nginx_helmchart/ingress-nginx/templates/controller-deployment.yaml
+++ b/tests/golden/defaults/ingress-nginx/ingress-nginx/10_ingress_nginx_helmchart/ingress-nginx/templates/controller-deployment.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.6.4
-    helm.sh/chart: ingress-nginx-4.5.2
+    app.kubernetes.io/version: 1.8.0
+    helm.sh/chart: ingress-nginx-4.7.0
   name: ingress-nginx-controller
   namespace: syn-ingress-nginx
 spec:
@@ -25,7 +25,11 @@ spec:
       labels:
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: ingress-nginx
+        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
+        app.kubernetes.io/part-of: ingress-nginx
+        app.kubernetes.io/version: 1.8.0
+        helm.sh/chart: ingress-nginx-4.7.0
     spec:
       containers:
         - args:
@@ -49,7 +53,7 @@ spec:
                   fieldPath: metadata.namespace
             - name: LD_PRELOAD
               value: /usr/local/lib/libmimalloc.so
-          image: registry.k8s.io/ingress-nginx/controller-chroot:v1.6.4@sha256:0de01e2c316c3ca7847ca13b32d077af7910d07f21a4a82f81061839764f8f81
+          image: registry.k8s.io/ingress-nginx/controller-chroot:v1.8.0@sha256:a45e41cd2b7670adf829759878f512d4208d0aec1869dae593a0fecd09a5e49e
           imagePullPolicy: IfNotPresent
           lifecycle:
             preStop:

--- a/tests/golden/defaults/ingress-nginx/ingress-nginx/10_ingress_nginx_helmchart/ingress-nginx/templates/controller-ingressclass.yaml
+++ b/tests/golden/defaults/ingress-nginx/ingress-nginx/10_ingress_nginx_helmchart/ingress-nginx/templates/controller-ingressclass.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.6.4
-    helm.sh/chart: ingress-nginx-4.5.2
+    app.kubernetes.io/version: 1.8.0
+    helm.sh/chart: ingress-nginx-4.7.0
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx

--- a/tests/golden/defaults/ingress-nginx/ingress-nginx/10_ingress_nginx_helmchart/ingress-nginx/templates/controller-poddisruptionbudget.yaml
+++ b/tests/golden/defaults/ingress-nginx/ingress-nginx/10_ingress_nginx_helmchart/ingress-nginx/templates/controller-poddisruptionbudget.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.6.4
-    helm.sh/chart: ingress-nginx-4.5.2
+    app.kubernetes.io/version: 1.8.0
+    helm.sh/chart: ingress-nginx-4.7.0
   name: ingress-nginx-controller
   namespace: syn-ingress-nginx
 spec:

--- a/tests/golden/defaults/ingress-nginx/ingress-nginx/10_ingress_nginx_helmchart/ingress-nginx/templates/controller-role.yaml
+++ b/tests/golden/defaults/ingress-nginx/ingress-nginx/10_ingress_nginx_helmchart/ingress-nginx/templates/controller-role.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.6.4
-    helm.sh/chart: ingress-nginx-4.5.2
+    app.kubernetes.io/version: 1.8.0
+    helm.sh/chart: ingress-nginx-4.7.0
   name: ingress-nginx
   namespace: syn-ingress-nginx
 rules:

--- a/tests/golden/defaults/ingress-nginx/ingress-nginx/10_ingress_nginx_helmchart/ingress-nginx/templates/controller-rolebinding.yaml
+++ b/tests/golden/defaults/ingress-nginx/ingress-nginx/10_ingress_nginx_helmchart/ingress-nginx/templates/controller-rolebinding.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.6.4
-    helm.sh/chart: ingress-nginx-4.5.2
+    app.kubernetes.io/version: 1.8.0
+    helm.sh/chart: ingress-nginx-4.7.0
   name: ingress-nginx
   namespace: syn-ingress-nginx
 roleRef:

--- a/tests/golden/defaults/ingress-nginx/ingress-nginx/10_ingress_nginx_helmchart/ingress-nginx/templates/controller-service-metrics.yaml
+++ b/tests/golden/defaults/ingress-nginx/ingress-nginx/10_ingress_nginx_helmchart/ingress-nginx/templates/controller-service-metrics.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.6.4
-    helm.sh/chart: ingress-nginx-4.5.2
+    app.kubernetes.io/version: 1.8.0
+    helm.sh/chart: ingress-nginx-4.7.0
   name: ingress-nginx-controller-metrics
   namespace: syn-ingress-nginx
 spec:

--- a/tests/golden/defaults/ingress-nginx/ingress-nginx/10_ingress_nginx_helmchart/ingress-nginx/templates/controller-service-webhook.yaml
+++ b/tests/golden/defaults/ingress-nginx/ingress-nginx/10_ingress_nginx_helmchart/ingress-nginx/templates/controller-service-webhook.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.6.4
-    helm.sh/chart: ingress-nginx-4.5.2
+    app.kubernetes.io/version: 1.8.0
+    helm.sh/chart: ingress-nginx-4.7.0
   name: ingress-nginx-controller-admission
   namespace: syn-ingress-nginx
 spec:

--- a/tests/golden/defaults/ingress-nginx/ingress-nginx/10_ingress_nginx_helmchart/ingress-nginx/templates/controller-service.yaml
+++ b/tests/golden/defaults/ingress-nginx/ingress-nginx/10_ingress_nginx_helmchart/ingress-nginx/templates/controller-service.yaml
@@ -8,8 +8,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.6.4
-    helm.sh/chart: ingress-nginx-4.5.2
+    app.kubernetes.io/version: 1.8.0
+    helm.sh/chart: ingress-nginx-4.7.0
   name: ingress-nginx-controller
   namespace: syn-ingress-nginx
 spec:

--- a/tests/golden/defaults/ingress-nginx/ingress-nginx/10_ingress_nginx_helmchart/ingress-nginx/templates/controller-serviceaccount.yaml
+++ b/tests/golden/defaults/ingress-nginx/ingress-nginx/10_ingress_nginx_helmchart/ingress-nginx/templates/controller-serviceaccount.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.6.4
-    helm.sh/chart: ingress-nginx-4.5.2
+    app.kubernetes.io/version: 1.8.0
+    helm.sh/chart: ingress-nginx-4.7.0
   name: ingress-nginx
   namespace: syn-ingress-nginx

--- a/tests/golden/defaults/ingress-nginx/ingress-nginx/10_ingress_nginx_helmchart/ingress-nginx/templates/controller-servicemonitor.yaml
+++ b/tests/golden/defaults/ingress-nginx/ingress-nginx/10_ingress_nginx_helmchart/ingress-nginx/templates/controller-servicemonitor.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.6.4
-    helm.sh/chart: ingress-nginx-4.5.2
+    app.kubernetes.io/version: 1.8.0
+    helm.sh/chart: ingress-nginx-4.7.0
   name: ingress-nginx-controller
 spec:
   endpoints:


### PR DESCRIPTION
Includes the NGNIX Ingress Controller version v1.8.

Support for Kubernetes v1.23 has been removed.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
